### PR TITLE
Change image placeholder to encourage a different Image uploader

### DIFF
--- a/resources/views/civilian/businesses/create.blade.php
+++ b/resources/views/civilian/businesses/create.blade.php
@@ -21,7 +21,7 @@
                     <label class="block text-base font-medium text-white" for="logo">
                         Logo
                     </label>
-                    <input class="text-input" name="logo" placeholder="https://cdn.discordapp.com/..." type="url"
+                    <input class="text-input" name="logo" placeholder="https://www.fivemanage.com/upload..." type="url"
                         value="{{ old('logo') }}" />
                     <x-input-error :messages="$errors->get('logo')" class="mt-2" />
 

--- a/resources/views/civilian/civilians/create.blade.php
+++ b/resources/views/civilian/civilians/create.blade.php
@@ -46,7 +46,7 @@
                     <label class="block text-base font-medium text-white" for="picture">
                         Image URL <span class="text-gray-400">(optional)</span>
                     </label>
-                    <input class="text-input" name="picture" placeholder="https://cdn.discordapp.com/..." type="text"
+                    <input class="text-input" name="picture" placeholder="https://www.fivemanage.com/upload..." type="text"
                         value="{{ old('picture') }}" />
                     <x-input-error :messages="$errors->get('picture')" class="mt-2" />
                 </div>

--- a/resources/views/civilian/civilians/edit.blade.php
+++ b/resources/views/civilian/civilians/edit.blade.php
@@ -12,7 +12,7 @@
                     <label class="block text-base font-medium text-white" for="picture">
                         Image URL <span class="text-gray-400">(optional)</span>
                     </label>
-                    <input class="text-input" name="picture" placeholder="https://cdn.discordapp.com/..." type="text"
+                    <input class="text-input" name="picture" placeholder="https://www.fivemanage.com/upload..." type="text"
                         value="{{ old('picture') }}" />
                     <x-input-error :messages="$errors->get('picture')" class="mt-2" />
                 </div>

--- a/resources/views/civilian/officer/create.blade.php
+++ b/resources/views/civilian/officer/create.blade.php
@@ -46,7 +46,7 @@
                     <label class="block text-base font-medium text-white" for="picture">
                         Image URL <span class="text-gray-400">(optional)</span>
                     </label>
-                    <input class="text-input" name="picture" placeholder="https://cdn.discordapp.com/..." type="text"
+                    <input class="text-input" name="picture" placeholder="https://www.fivemanage.com/upload..." type="text"
                         value="{{ old('picture') }}" />
                     <x-input-error :messages="$errors->get('picture')" class="mt-2" />
                 </div>

--- a/resources/views/civilian/officer/edit.blade.php
+++ b/resources/views/civilian/officer/edit.blade.php
@@ -12,7 +12,7 @@
                     <label class="block text-base font-medium text-white" for="picture">
                         Image URL <span class="text-gray-400">(optional)</span>
                     </label>
-                    <input class="text-input" name="picture" placeholder="https://cdn.discordapp.com/..." type="text"
+                    <input class="text-input" name="picture" placeholder="https://www.fivemanage.com/upload..." type="text"
                         value="{{ old('picture') }}" />
                     <x-input-error :messages="$errors->get('picture')" class="mt-2" />
                 </div>


### PR DESCRIPTION
With Discord CDN links expiring after 24 Hours and Imgurs recent changes, something new will need to be used for File Uploading to make sure the links do not break. FiveManage is a great uploader we use with some resources and could be a good alternate, unless Community CAD Host their own, or we allow file uploads instead of links!